### PR TITLE
refactor(*): consolidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"dependencies": {
 		"@octokit/request": "^6.2.0",
 		"@octokit/request-error": "^3.0.0",
+		"@octokit/types": "^8.0.0",
 		"@octokit/webhooks-methods": "^3.0.0",
 		"node-fetch": "^3.2.10"
 	},

--- a/src/api/_lib/handlers/commitComment.ts
+++ b/src/api/_lib/handlers/commitComment.ts
@@ -1,8 +1,8 @@
 import { request } from '@octokit/request';
 import type { CommitCommentEvent } from '@octokit/webhooks-types';
-import { PackageName } from '../utils/constants.js';
 import { filterCommitComments } from '../utils/filters.js';
-import { DiscordWebhooksTarget, PerPackageWebhooks } from '../utils/webhooks.js';
+import { getTargetFromFiles } from '../utils/functions.js';
+import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
 /**
  * Gets the target for incoming commit comment type webhooks
@@ -20,15 +20,5 @@ export async function getCommitCommentRewriteTarget(event: CommitCommentEvent): 
 
 	const commit = commitResponse.data;
 
-	let singlePackage: PackageName | null = null;
-
-	for (const name of Object.values(PackageName)) {
-		if (commit.files?.some((file) => file.filename.startsWith(`packages/${name}/`))) {
-			if (singlePackage) return 'monorepo';
-			singlePackage = name;
-		}
-	}
-
-	if (!singlePackage) return 'monorepo';
-	return PerPackageWebhooks[singlePackage];
+	return getTargetFromFiles(commit.files);
 }

--- a/src/api/_lib/handlers/issues.ts
+++ b/src/api/_lib/handlers/issues.ts
@@ -1,6 +1,6 @@
 import type { IssueCommentEvent, IssuesEvent } from '@octokit/webhooks-types';
 import { filterPrComments } from '../utils/filters.js';
-import { getPackageLabelTarget, getPotentialPackageTarget } from '../utils/functions.js';
+import { getLabelTarget, getPotentialTarget } from '../utils/functions.js';
 import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
 /**
@@ -11,8 +11,8 @@ import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 export function getIssueRewriteTarget(event: IssueCommentEvent | IssuesEvent): DiscordWebhooksTarget {
 	if (filterPrComments(event)) return 'none';
 
-	const packageLabel = getPackageLabelTarget(event.issue.labels);
-	if (packageLabel) return packageLabel;
+	const label = getLabelTarget(event.issue.labels);
+	if (label) return label;
 
 	if (!event.issue.body) return 'monorepo';
 
@@ -22,5 +22,5 @@ export function getIssueRewriteTarget(event: IssueCommentEvent | IssuesEvent): D
 
 	const potentialPackage = splitBody[2];
 	if (!potentialPackage) return 'monorepo';
-	return getPotentialPackageTarget(potentialPackage);
+	return getPotentialTarget(potentialPackage);
 }

--- a/src/api/_lib/handlers/push.ts
+++ b/src/api/_lib/handlers/push.ts
@@ -11,7 +11,8 @@ import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 function checkModified(prefix: string, commit: Commit) {
 	return (
 		commit.added.some((file) => file.startsWith(prefix)) ||
-		commit.modified.some((file) => file.startsWith(prefix) || commit.removed.some((file) => file.startsWith(prefix)))
+		commit.modified.some((file) => file.startsWith(prefix)) ||
+		commit.removed.some((file) => file.startsWith(prefix))
 	);
 }
 

--- a/src/api/_lib/handlers/push.ts
+++ b/src/api/_lib/handlers/push.ts
@@ -1,5 +1,5 @@
 import type { PushEvent } from '@octokit/webhooks-types';
-import { AppName, PackageName } from '../utils/constants.js';
+import { type AppName, AppNameValues, type PackageName, PackageNameValues } from '../utils/constants.js';
 import { getFinalTarget } from '../utils/functions.js';
 import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
@@ -15,25 +15,27 @@ export function getPushRewriteTarget(event: PushEvent): DiscordWebhooksTarget {
 	const targets = new Set<AppName | PackageName>();
 
 	for (const commit of event.commits) {
-		for (const name of Object.values(AppName)) {
-			if (commit.added.some((file) => file.startsWith(`apps/${name}/`))) {
+		for (const name of AppNameValues) {
+			const prefix = `apps/${name}/`;
+			if (commit.added.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
-			if (commit.modified.some((file) => file.startsWith(`apps/${name}/`))) {
+			if (commit.modified.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
-			if (commit.removed.some((file) => file.startsWith(`apps/${name}/`))) {
+			if (commit.removed.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
 		}
-		for (const name of Object.values(PackageName)) {
-			if (commit.added.some((file) => file.startsWith(`packages/${name}/`))) {
+		for (const name of PackageNameValues) {
+			const prefix = `packages/${name}/`;
+			if (commit.added.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
-			if (commit.modified.some((file) => file.startsWith(`packages/${name}/`))) {
+			if (commit.modified.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
-			if (commit.removed.some((file) => file.startsWith(`packages/${name}/`))) {
+			if (commit.removed.some((file) => file.startsWith(prefix))) {
 				targets.add(name);
 			}
 		}

--- a/src/api/_lib/handlers/push.ts
+++ b/src/api/_lib/handlers/push.ts
@@ -1,6 +1,7 @@
 import type { PushEvent } from '@octokit/webhooks-types';
-import { PackageName } from '../utils/constants.js';
-import { DiscordWebhooksTarget, PerPackageWebhooks } from '../utils/webhooks.js';
+import { AppName, PackageName } from '../utils/constants.js';
+import { getFinalTarget } from '../utils/functions.js';
+import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
 /**
  * Gets the target for incoming push type webhooks
@@ -11,23 +12,34 @@ export function getPushRewriteTarget(event: PushEvent): DiscordWebhooksTarget {
 	// Workaround for pre-monorepo
 	if (event.ref === 'refs/heads/v13') return 'discord.js';
 
-	const packages = new Set<PackageName>();
+	const targets = new Set<AppName | PackageName>();
 
 	for (const commit of event.commits) {
+		for (const name of Object.values(AppName)) {
+			if (commit.added.some((file) => file.startsWith(`apps/${name}/`))) {
+				targets.add(name);
+			}
+			if (commit.modified.some((file) => file.startsWith(`apps/${name}/`))) {
+				targets.add(name);
+			}
+			if (commit.removed.some((file) => file.startsWith(`apps/${name}/`))) {
+				targets.add(name);
+			}
+		}
 		for (const name of Object.values(PackageName)) {
 			if (commit.added.some((file) => file.startsWith(`packages/${name}/`))) {
-				packages.add(name);
+				targets.add(name);
 			}
 			if (commit.modified.some((file) => file.startsWith(`packages/${name}/`))) {
-				packages.add(name);
+				targets.add(name);
 			}
 			if (commit.removed.some((file) => file.startsWith(`packages/${name}/`))) {
-				packages.add(name);
+				targets.add(name);
 			}
 		}
 	}
 
-	const [firstPackage] = packages;
-	if (packages.size === 1) return PerPackageWebhooks[firstPackage!];
+	const [firstPackage] = targets;
+	if (targets.size === 1) return getFinalTarget(firstPackage!);
 	return 'monorepo';
 }

--- a/src/api/_lib/handlers/release.ts
+++ b/src/api/_lib/handlers/release.ts
@@ -1,6 +1,6 @@
 import type { ReleaseEvent } from '@octokit/webhooks-types';
 import { PackageName } from '../utils/constants.js';
-import { getPotentialPackageTarget } from '../utils/functions.js';
+import { getPotentialTarget } from '../utils/functions.js';
 import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
 /**
@@ -12,5 +12,5 @@ export function getReleaseRewriteTarget(event: ReleaseEvent): DiscordWebhooksTar
 	let potentialPackage = event.release.tag_name.split('/')[1]?.split('@')[0];
 	if (!potentialPackage && /^\d+\.\d+\.\d+$/gm.test(event.release.tag_name)) potentialPackage = PackageName.DiscordJS;
 	if (!potentialPackage) return 'monorepo';
-	return getPotentialPackageTarget(potentialPackage);
+	return getPotentialTarget(potentialPackage);
 }

--- a/src/api/_lib/handlers/tagOrBanrch.ts
+++ b/src/api/_lib/handlers/tagOrBanrch.ts
@@ -1,6 +1,6 @@
 import type { CreateEvent, DeleteEvent } from '@octokit/webhooks-types';
 import { PackageName } from '../utils/constants.js';
-import { getPotentialPackageTarget } from '../utils/functions.js';
+import { getPotentialTarget } from '../utils/functions.js';
 import type { DiscordWebhooksTarget } from '../utils/webhooks.js';
 
 /**
@@ -12,5 +12,5 @@ export function getTagOrBranchTarget(event: CreateEvent | DeleteEvent): DiscordW
 	let potentialPackage = event.ref.split('/')[1]?.split('@')[0];
 	if (!potentialPackage && /^\d+\.\d+\.\d+$/gm.test(event.ref)) potentialPackage = PackageName.DiscordJS;
 	if (!potentialPackage) return 'monorepo';
-	return getPotentialPackageTarget(potentialPackage);
+	return getPotentialTarget(potentialPackage);
 }

--- a/src/api/_lib/utils/constants.ts
+++ b/src/api/_lib/utils/constants.ts
@@ -27,6 +27,8 @@ export enum AppName {
 	Website = 'website',
 }
 
+export const AppNameValues = Object.values(AppName);
+
 export enum PackageName {
 	Actions = 'actions',
 	Brokers = 'brokers',
@@ -45,6 +47,8 @@ export enum PackageName {
 	Voice = 'voice',
 	Ws = 'ws',
 }
+
+export const PackageNameValues = Object.values(PackageName);
 
 export const DiscardVercelPrComments = process.env.DISCARD_VERCEL_PR_COMMENTS === 'true';
 export const DiscardVercelCommitComments = process.env.DISCARD_VERCEL_COMMIT_COMMENTS === 'true';

--- a/src/api/_lib/utils/constants.ts
+++ b/src/api/_lib/utils/constants.ts
@@ -22,6 +22,11 @@ export enum FilterCheckedEvent {
 	PullRequestReviewThread = 'pull_request_review_thread',
 }
 
+export enum AppName {
+	Guide = 'guide',
+	Website = 'website',
+}
+
 export enum PackageName {
 	Actions = 'actions',
 	Brokers = 'brokers',
@@ -29,7 +34,6 @@ export enum PackageName {
 	Collection = 'collection',
 	DiscordJS = 'discord.js',
 	Docgen = 'docgen',
-	Guide = 'guide',
 	Proxy = 'proxy',
 	ProxyContainer = 'proxy-container',
 	Rest = 'rest',
@@ -39,7 +43,6 @@ export enum PackageName {
 	Ui = 'ui',
 	Util = 'util',
 	Voice = 'voice',
-	Website = 'website',
 	Ws = 'ws',
 }
 

--- a/src/api/_lib/utils/functions.ts
+++ b/src/api/_lib/utils/functions.ts
@@ -1,6 +1,7 @@
+import type { Endpoints } from '@octokit/types';
 import type { Label } from '@octokit/webhooks-types';
-import type { PackageName } from './constants.js';
-import { PerPackageWebhooks } from './webhooks.js';
+import { AppName, PackageName } from './constants.js';
+import { DiscordWebhooksTarget, OverideWebhooks } from './webhooks.js';
 
 /**
  * `Array#includes` but it works for enums
@@ -16,17 +17,30 @@ export function enumIncludes<StrictType extends Generic, Generic>(
 }
 
 /**
- * Gets the target for a (potential) package name, if the package name isn't found, returns `monorepo`
- * @param potentialPackage The package name to try to get a target for
+ * Gets the final target for a package / app name, taking into account overrides
+ * @param target The package / app name that is the initial target
+ * @returns The determined final target
+ */
+export function getFinalTarget(target: AppName | PackageName): DiscordWebhooksTarget {
+	// For some reason typescript doesn't get this
+	if (target in OverideWebhooks) return OverideWebhooks[target]!;
+	return target;
+}
+
+/**
+ * Gets the target for a (potential) package / app name, if the package / app name isn't found, returns `monorepo`
+ * @param potentialName The package / app name to try to get a target for
  * @returns The determined target
  */
-export function getPotentialPackageTarget(potentialPackage: string) {
-	const target = PerPackageWebhooks[potentialPackage.trim().toLowerCase() as PackageName];
+export function getPotentialTarget(potentialName: string) {
+	const conformedPotentialName = potentialName.trim().toLowerCase();
+	const isTarget = enumIncludes(AppName, conformedPotentialName) || enumIncludes(PackageName, conformedPotentialName);
+
 	// Probablly not often but if a package label is added that isn't accounted for it should just go to the monorepo webhook
 	// Same if user edits a packge name manually in an issue description
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-	if (!target) return 'monorepo';
-	return target;
+	if (!isTarget) return 'monorepo';
+
+	return getFinalTarget(conformedPotentialName);
 }
 
 /**
@@ -34,10 +48,40 @@ export function getPotentialPackageTarget(potentialPackage: string) {
  * @param labels The labels on the pull request or issue
  * @returns The determined target
  */
-export function getPackageLabelTarget(labels?: Label[]) {
+export function getLabelTarget(labels?: Label[]) {
 	if (!labels) return null;
-	const packageLabels = labels.filter((label) => label.name.startsWith('packages:'));
-	if (packageLabels.length < 1) return null;
-	if (packageLabels.length > 1) return 'monorepo';
-	return getPotentialPackageTarget(packageLabels[0]!.name.split(':')[1]!);
+	const packageAppLabels = labels.filter(
+		(label) => label.name.startsWith('packages:') || label.name.startsWith('apps:'),
+	);
+	if (packageAppLabels.length < 1) return null;
+	if (packageAppLabels.length > 1) return 'monorepo';
+	return getPotentialTarget(packageAppLabels[0]!.name.split(':')[1]!);
+}
+
+/**
+ * Get the target for a pull request or commit comment based on the changed files
+ * @param files The files as returned by github
+ * @returns The determined target
+ */
+export function getTargetFromFiles(
+	files:
+		| Endpoints['GET /repos/{owner}/{repo}/commits/{ref}']['response']['data']['files']
+		| Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/files']['response']['data'],
+) {
+	if (!files) return 'monorepo';
+	let singleTarget: AppName | PackageName | null = null;
+	for (const name of Object.values(AppName)) {
+		if (files.some((file) => file.filename.startsWith(`apps/${name}/`))) {
+			if (singleTarget) return 'monorepo';
+			singleTarget = name;
+		}
+	}
+	for (const name of Object.values(PackageName)) {
+		if (files.some((file) => file.filename.startsWith(`packages/${name}/`))) {
+			if (singleTarget) return 'monorepo';
+			singleTarget = name;
+		}
+	}
+	if (!singleTarget) return 'monorepo';
+	return getFinalTarget(singleTarget);
 }

--- a/src/api/_lib/utils/webhooks.ts
+++ b/src/api/_lib/utils/webhooks.ts
@@ -1,4 +1,4 @@
-import type { PackageName } from './constants.js';
+import { AppName, PackageName } from './constants.js';
 
 const useForum = process.env.USE_FORUM === 'true';
 
@@ -8,25 +8,19 @@ if (typeof webhookBase !== 'string') {
 	throw new TypeError('DISCORD_WEBHOOK_FORUM_BASE must be defined to use forums');
 }
 
-// TODO cleanup, somehow use PackageName to only update one place for new packages
-
+// If we don't cast then we have to add all the package / app names here again!
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const Webhooks = {
 	monorepo: process.env.DISCORD_WEBHOOK_MONOREPO,
-	brokers: process.env.DISCORD_WEBHOOK_BROKERS,
-	builders: process.env.DISCORD_WEBHOOK_BUILDERS,
-	collection: process.env.DISCORD_WEBHOOK_COLLECTION,
-	'discord.js': process.env.DISCORD_WEBHOOK_DISCORDJS,
-	guide: process.env.DISCORD_WEBHOOK_GUIDE,
-	proxy: process.env.DISCORD_WEBHOOK_PROXY,
-	rest: process.env.DISCORD_WEBHOOK_REST,
-	sharder: process.env.DISCORD_WEBHOOK_SHARDER,
-	structures: process.env.DISCORD_WEBHOOK_STRUCTURES,
-	ui: process.env.DISCORD_WEBHOOK_UI,
-	util: process.env.DISCORD_WEBHOOK_UTIL,
-	voice: process.env.DISCORD_WEBHOOK_VOICE,
-	website: process.env.DISCORD_WEBHOOK_WEBSITE,
-	ws: process.env.DISCORD_WEBHOOK_WS,
-} as const;
+} as Record<`${AppName | PackageName}` | 'monorepo', string | undefined>;
+
+for (const packageName of Object.entries(PackageName)) {
+	Webhooks[packageName[1]] = process.env[`DISCORD_WEBHOOK_${packageName[0].toUpperCase()}`];
+}
+
+for (const appName of Object.entries(AppName)) {
+	Webhooks[appName[1]] = process.env[`DISCORD_WEBHOOK_${appName[0].toUpperCase()}`];
+}
 
 const ForumWebhooks = Object.entries(Webhooks).reduce(
 	(acc, [pack, val]) => ({ ...acc, [pack]: val ? `${webhookBase}?thread_id=${val}` : undefined }),
@@ -37,23 +31,6 @@ export const DiscordWebhooks = useForum ? ForumWebhooks : Webhooks;
 
 export type DiscordWebhooksTarget = keyof typeof DiscordWebhooks | 'none';
 
-export const PerPackageWebhooks: Record<PackageName, DiscordWebhooksTarget> = {
-	actions: 'monorepo',
-	brokers: 'brokers',
-	builders: 'builders',
-	collection: 'collection',
-	'discord.js': 'discord.js',
-	docgen: 'monorepo',
-	guide: 'guide',
-	proxy: 'proxy',
+export const OverideWebhooks: Partial<Record<AppName | PackageName, DiscordWebhooksTarget>> = {
 	'proxy-container': 'proxy',
-	rest: 'rest',
-	scripts: 'monorepo',
-	sharder: 'sharder',
-	structures: 'structures',
-	ui: 'ui',
-	util: 'util',
-	voice: 'voice',
-	website: 'website',
-	ws: 'ws',
 };

--- a/src/api/_lib/utils/webhooks.ts
+++ b/src/api/_lib/utils/webhooks.ts
@@ -31,6 +31,6 @@ export const DiscordWebhooks = useForum ? ForumWebhooks : Webhooks;
 
 export type DiscordWebhooksTarget = keyof typeof DiscordWebhooks | 'none';
 
-export const OverideWebhooks: Partial<Record<AppName | PackageName, DiscordWebhooksTarget>> = {
+export const OverrideWebhooks: Partial<Record<AppName | PackageName, DiscordWebhooksTarget>> = {
 	'proxy-container': 'proxy',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,6 +127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/openapi-types@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@octokit/openapi-types@npm:14.0.0"
+  checksum: 0a1f8f3be998cd82c5a640e9166d43fd183b33d5d36f5e1a9b81608e94d0da87c01ec46c9988f69cd26585d4e2ffc4d3ec99ee4f75e5fe997fc86dad0aa8293c
+  languageName: node
+  linkType: hard
+
 "@octokit/request-error@npm:^3.0.0":
   version: 3.0.0
   resolution: "@octokit/request-error@npm:3.0.0"
@@ -158,6 +165,15 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": ^12.7.0
   checksum: 0e3d55e4bdef41e652a2e99a304cebada90f23a90619c49ab892a76ae908c4281316738453348c9ba30b32250ef5eda0a939c2af3aec5ca808acdf9922da420c
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@octokit/types@npm:8.0.0"
+  dependencies:
+    "@octokit/openapi-types": ^14.0.0
+  checksum: 1a0197b2c4c522ac90f145e02b3f8cb048a47f71c2c6bdbf021a03db7dd30ca92a899c0186acb401337f218efe44e60d33cc1cc68715b622bb75bc1a4e79515d
   languageName: node
   linkType: hard
 
@@ -1900,6 +1916,7 @@ __metadata:
   dependencies:
     "@octokit/request": ^6.2.0
     "@octokit/request-error": ^3.0.0
+    "@octokit/types": ^8.0.0
     "@octokit/webhooks-methods": ^3.0.0
     "@octokit/webhooks-types": ^6.2.4
     "@types/estree": ^1.0.0


### PR DESCRIPTION
Some of this code was quite redundant, especially when adding new packages / apps

This refactor should make it 1 line changes to add new packages / apps (excluding readme docs).

Additionally, in order to support the refactor, the split to apps was made here. It should otherwise be identical to the functionality before the refactor.