### PR TITLE
feat(filter): add renovate discard

### DIFF
--- a/src/api/_lib/handlers/push.ts
+++ b/src/api/_lib/handlers/push.ts
@@ -1,4 +1,5 @@
 import type { Commit, PushEvent } from '@octokit/webhooks-types';
+import { filterPushes } from '../utils/filters.js';
 import { getFinalTarget } from '../utils/functions.js';
 import { AppNames, PackageNames } from '../utils/webhooks.js';
 
@@ -23,6 +24,7 @@ function checkModified(prefix: string, commit: Commit) {
  * @returns The target name
  */
 export function getPushRewriteTarget(event: PushEvent): string {
+	if (filterPushes(event)) return 'none';
 	// Workaround for pre-monorepo
 	if (event.ref === 'refs/heads/v13') return 'discord.js';
 

--- a/src/api/_lib/handlers/tagOrBranch.ts
+++ b/src/api/_lib/handlers/tagOrBranch.ts
@@ -1,4 +1,5 @@
 import type { CreateEvent, DeleteEvent } from '@octokit/webhooks-types';
+import { filterTagOrBranches } from '../utils/filters.js';
 import { getPotentialTarget } from '../utils/functions.js';
 
 /**
@@ -8,6 +9,7 @@ import { getPotentialTarget } from '../utils/functions.js';
  * @returns The target name
  */
 export function getTagOrBranchTarget(event: CreateEvent | DeleteEvent): string {
+	if (filterTagOrBranches(event)) return 'none';
 	let potentialPackage = event.ref.split('/')[1]?.split('@')[0];
 	if (!potentialPackage && /^\d+\.\d+\.\d+$/gm.test(event.ref)) potentialPackage = 'discord.js';
 	if (!potentialPackage) return 'monorepo';

--- a/src/api/_lib/utils/constants.ts
+++ b/src/api/_lib/utils/constants.ts
@@ -22,6 +22,9 @@ export enum FilterCheckedEvent {
 	PullRequestReview = 'pull_request_review',
 	PullRequestReviewComment = 'pull_request_review_comment',
 	PullRequestReviewThread = 'pull_request_review_thread',
+	Push = 'push',
+	TagOrBranchCreate = 'create',
+	TagOrBranchDelete = 'delete',
 }
 
 export interface EdgeConfig {
@@ -32,28 +35,31 @@ export interface EdgeConfig {
 	};
 	debugLogs?: boolean;
 	discard?: {
-		codecov?: DiscardCommentTypes;
-		githubActions?: DiscardCommentTypes;
-		vercel?: DiscardCommentTypes;
+		codecov?: DiscardTypes;
+		githubActions?: DiscardTypes;
+		renovate?: DiscardTypes;
+		vercel?: DiscardTypes;
 	};
 	overrideWebhooks?: {
 		apps?: Record<string, string>;
 		packages?: Record<string, string>;
 	};
 }
-export interface DiscardCommentTypes {
+export interface DiscardTypes {
 	commitComments?: boolean;
 	prComments?: boolean;
+	push?: boolean;
+	tagOrBranch?: boolean;
 }
 
-const discard = await get<EdgeConfig['discard']>('discard');
+export const discardConfig = await get<EdgeConfig['discard']>('discard');
+export const discardConfigEntries = discardConfig
+	? (Object.entries(discardConfig) as [keyof NonNullable<EdgeConfig['discard']>, Readonly<DiscardTypes>][])
+	: [];
 
-export const DiscardVercelPrComments = discard?.vercel?.prComments === true;
-export const DiscardVercelCommitComments = discard?.vercel?.commitComments === true;
-export const VercelBotId = 35_613_825;
-export const DiscardCodecovPrComments = discard?.codecov?.prComments === true;
-export const DiscardCodecovCommitComments = discard?.codecov?.commitComments === true;
-export const CodecovBotId = 22_429_695;
-export const DiscardGithubActionsPrComments = discard?.githubActions?.prComments === true;
-export const DiscardGithubActionsCommitComments = discard?.githubActions?.commitComments === true;
-export const GithubActionsBotId = 41_898_282;
+export const botIds: Record<keyof NonNullable<EdgeConfig['discard']>, number> = {
+	codecov: 22_429_695,
+	githubActions: 41_898_282,
+	renovate: 29_139_614,
+	vercel: 35_613_825,
+};


### PR DESCRIPTION
Adds filtering for renovate. This now allows push events and tag / branch events to be filtered.

Also cleans up the filter logic a little bit to make future filter edits easier.